### PR TITLE
Dockerfile.alpine: use upstream docker image as builder

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -1,6 +1,7 @@
 name: DockerHub
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - '*'

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -22,7 +22,7 @@ jobs:
         uses: crazy-max/ghaction-docker-meta@v2
         with:
           images: |
-            neilpang/wgcf-docker
+            ${{ secrets.DOCKERHUB_USERNAME }}/wgcf-docker
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -66,7 +66,7 @@ jobs:
         uses: crazy-max/ghaction-docker-meta@v2
         with:
           images: |
-            neilpang/wgcf-docker
+            ${{ secrets.DOCKERHUB_USERNAME }}/wgcf-docker
           tags: |
             type=semver,suffix=-alpine,pattern={{version}}
             type=semver,suffix=-alpine,pattern={{major}}.{{minor}}

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,3 +1,5 @@
+FROM virb3/wgcf:2.2 AS builder
+
 FROM alpine:3
 
 
@@ -9,7 +11,8 @@ RUN apk update -f \
   && rm -rf /var/cache/apk/*
   
   
-RUN curl -fsSL git.io/wgcf.sh | bash && mkdir -p /wgcf
+COPY --from=builder "/wgcf" "/usr/local/bin/wgcf"
+RUN mkdir -p /wgcf
 
 WORKDIR /wgcf
 


### PR DESCRIPTION
Use virb3/wgcf as builder, so there is no need to depend on a third party script.